### PR TITLE
[DEV] Clean instead of stacking plotting states

### DIFF
--- a/src/aesthetics.rs
+++ b/src/aesthetics.rs
@@ -332,7 +332,7 @@ fn build_axes(
                 };
                 let axis_entry = axes
                     .entry(arrow.id.clone())
-                    .or_insert(HashMap::new())
+                    .or_default()
                     .entry(geom.side.clone())
                     .or_insert((
                         Xaxis {
@@ -413,7 +413,7 @@ fn build_point_axes(
                 };
                 let axis_entry = axes
                     .entry(arrow.id.clone())
-                    .or_insert(HashMap::new())
+                    .or_default()
                     .entry(geom.side.clone())
                     .or_insert((
                         Xaxis {

--- a/src/data.rs
+++ b/src/data.rs
@@ -421,7 +421,7 @@ fn load_data(
 fn insert_geom_map<Aes: Component, Geom: Component>(
     commands: &mut Commands,
     indices: &HashSet<usize>,
-    aes_data: &mut [Number],
+    aes_data: &[Number],
     identifiers: &[String],
     ggcomp: GgPair<Aes, Geom>,
 ) {

--- a/src/escher.rs
+++ b/src/escher.rs
@@ -470,13 +470,13 @@ pub fn load_map(
                     (Some(BezierHandle { x, y }), None) | (None, Some(BezierHandle { x, y })) => {
                         last_from = Vec2::new(x, -y);
                         path_builder.quadratic_bezier_to(last_from - ori, re_to - ori);
-                        last_from = last_from - (re_to - re_from) / 2.;
+                        last_from -= (re_to - re_from) / 2.;
                     }
                     (Some(BezierHandle { x: x1, y: y1 }), Some(BezierHandle { x: x2, y: y2 })) => {
                         let prev_from = Vec2::new(x1, -y1);
                         last_from = Vec2::new(x2, -y2);
                         path_builder.cubic_bezier_to(prev_from - ori, last_from - ori, re_to - ori);
-                        last_from = last_from - (re_to - prev_from) / 2.;
+                        last_from -= (re_to - prev_from) / 2.;
                     }
                     (None, None) => {
                         path_builder.line_to(re_to - ori);

--- a/src/escher.rs
+++ b/src/escher.rs
@@ -201,11 +201,9 @@ impl Reaction {
                 _ => None,
             })
             .collect();
-        info!("Products for {}", self.bigg_id);
         self.metabolites
             .iter()
             .filter(|met| met.coefficient > 1e-6)
-            .inspect(|m| info!("{}", m.bigg_id))
             .map(|met| {
                 (
                     met_to_node_id[met.bigg_id.as_str()].0.to_string(),
@@ -273,11 +271,17 @@ pub struct ArrowTag {
 
 pub trait Tag: Component {
     fn id(&self) -> &str;
+    fn default_color() -> Color {
+        ARROW_COLOR
+    }
 }
 
 impl Tag for CircleTag {
     fn id(&self) -> &str {
         &self.id
+    }
+    fn default_color() -> Color {
+        MET_COLOR
     }
 }
 
@@ -478,7 +482,7 @@ pub fn load_map(
                         path_builder.line_to(re_to - ori);
                     }
                 }
-                if let Some((drawn, importance)) = products.get_mut(&segment.to_node_id) {
+                if let Some((drawn, importance)) = products.get_mut(segment.to_node_id.as_str()) {
                     if !*drawn {
                         let offset = match importance {
                             MetImportance::Primary => 22.0,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -281,9 +281,8 @@ pub fn file_drop(
             if path_buf.to_str().unwrap().ends_with("metabolism.json") {
                 let reaction_handle: Handle<Data> = asset_server.load(path_buf.to_str().unwrap());
                 reaction_resource.reaction_data = Some(reaction_handle);
-                reaction_resource.reac_loaded = false;
-                reaction_resource.met_loaded = false;
-                info_state.notify("Loading data...");
+                reaction_resource.loaded = false;
+                info_state.notify("(gui) Loading data...");
             } else {
                 //an escher map
                 let escher_handle: Handle<EscherMap> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
                 })
                 .set(ImagePlugin::default_linear()),
         )
-        .add_plugin(PanCamPlugin::default())
+        .add_plugin(PanCamPlugin)
         .add_plugin(info::InfoPlugin)
         .add_plugin(ShapePlugin)
         .add_plugin(EscherPlugin)
@@ -173,7 +173,7 @@ fn main() {
             },
             ..default()
         }))
-        .add_plugin(PanCamPlugin::default())
+        .add_plugin(PanCamPlugin)
         .add_plugin(ShapePlugin)
         .add_plugin(info::InfoPlugin)
         .add_plugin(EscherPlugin)

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,8 +193,7 @@ fn setup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
     commands.insert_resource(data::ReactionState {
         reaction_data: None,
-        reac_loaded: false,
-        met_loaded: false,
+        loaded: false,
     });
 
     commands


### PR DESCRIPTION
This is a changed behavior. 

### Problem

Before, data files could be stacked one after the other, replacing only the plot kinds that were added. The users are not usually expecting this behavior, and it has made them to close the application every time they wanted to change the plotted data.

### Solution

Now, adding new data simply removes the previously added data. This PR also removes the axis Transform updated in the previous data, we may want to consider keeping them.