### PR TITLE
[FEAT] Horizontally stacked boxpoints

### DIFF
--- a/ggshu/ggshu/aes.py
+++ b/ggshu/ggshu/aes.py
@@ -12,6 +12,7 @@ def aes(
     y: Optional[str] = None,
     color: Optional[str] = None,
     size: Optional[str] = None,
+    stack: Optional[str] = None,
 ) -> Aesthetics:
     """Map from dataframe variables to grammar graphics variables."""
     # instead of using **kwargs, we specify the exact accepted aes
@@ -24,5 +25,6 @@ def aes(
         "y": y,
         "color": color,
         "size": size,
+        "stack": stack,
     }
     return {k: v for k, v in aesthetics.items() if v is not None}

--- a/ggshu/tests/conftest.py
+++ b/ggshu/tests/conftest.py
@@ -10,6 +10,7 @@ def df():
     return pd.DataFrame(
         {
             "r": ["a", "a", "b", "b", "c", "c", None, None, None, None],
+            "iso": ["a1", "a1", "b1", "b2", "c1", "c2", None, None, None, None],
             "flux": [1, 2, 3, 4, 6, 6, None, None, None, None],
             "kcat": [2, 4, 6, 7, 9, 10, None, None, None, None],
             "conc": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],

--- a/ggshu/tests/test_ggdata.py
+++ b/ggshu/tests/test_ggdata.py
@@ -52,7 +52,7 @@ def test_plotting_metabolites_are_correctly_added_from_geoms(df):
         ggmap(df, aes(reaction="r", color="flux", size="flux", y="kcat"))
         + geom_arrow()
         + geom_metabolite(aes=aes(color="conc", metabolite="m"))
-        + geom_boxpoint(side="left")
+        + geom_boxpoint(side="left", aes=aes(stack="iso"))
     ).plotting_data
     assert [
         key in plotting_data

--- a/src/aesthetics.rs
+++ b/src/aesthetics.rs
@@ -623,7 +623,7 @@ fn plot_side_box(
                 if let Some(tag) = &ycat.tags[index] {
                     let mut text_trans = Transform::from_xyz(
                         // based y on the box size (40.) and the number of conditions
-                        -40. * 1.2 * axis.conditions.len() as f32,
+                        -40. * axis.conditions.len() as f32,
                         40.0 * ycat.idx[index] as f32 * 1.2 + 20.,
                         0.,
                     )

--- a/src/data.rs
+++ b/src/data.rs
@@ -191,7 +191,6 @@ struct GgPair<'a, Aes, Geom> {
     geom_component: Geom,
     cond: &'a str,
     hover: bool,
-    met: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -284,10 +283,9 @@ fn load_data(
                     &identifiers,
                     GgPair {
                         aes_component: aesthetics::Gcolor {},
-                        geom_component: geom::GeomArrow { plotted: false },
+                        geom_component: geom::GeomArrow {},
                         cond,
                         hover: false,
-                        met: false,
                     },
                 );
             }
@@ -301,10 +299,9 @@ fn load_data(
                         &identifiers,
                         GgPair {
                             aes_component: aesthetics::Gsize {},
-                            geom_component: geom::GeomArrow { plotted: false },
+                            geom_component: geom::GeomArrow {},
                             cond,
                             hover: false,
-                            met: false,
                         },
                     );
                 };
@@ -331,7 +328,6 @@ fn load_data(
                             geom_component,
                             cond,
                             hover: i > 3,
-                            met: false,
                         },
                     );
                 }
@@ -386,11 +382,11 @@ fn load_data(
                         aesthetics::Gy {},
                         aesthetics::Point(std::mem::take(&mut data)),
                         geom,
-                        AesFilter {
-                            met: false,
-                            pbox: true,
+                        AesFilter {},
+                        YCategory {
+                            idx: variant_indices,
+                            tags: str_variant.into_iter().map(|x| x.cloned()).collect(),
                         },
-                        YCategory(variant_indices),
                         aesthetics::Aesthetics {
                             identifiers: ids,
                             condition: if cond.is_empty() {
@@ -439,10 +435,9 @@ fn load_data(
                     &identifiers,
                     GgPair {
                         aes_component: aesthetics::Gcolor {},
-                        geom_component: geom::GeomMetabolite { plotted: false },
+                        geom_component: geom::GeomMetabolite {},
                         cond,
                         hover: false,
-                        met: false,
                     },
                 );
             }
@@ -454,10 +449,9 @@ fn load_data(
                     &identifiers,
                     GgPair {
                         aes_component: aesthetics::Gsize {},
-                        geom_component: geom::GeomMetabolite { plotted: false },
+                        geom_component: geom::GeomMetabolite {},
                         cond,
                         hover: false,
-                        met: false,
                     },
                 );
             }
@@ -478,7 +472,6 @@ fn load_data(
                             geom_component,
                             cond,
                             hover: true,
-                            met: true,
                         },
                     );
                 }
@@ -560,10 +553,7 @@ fn insert_geom_hist<Aes: Component, Geom: Component>(
             .insert((
                 ggcomp.aes_component,
                 aesthetics::Distribution(std::mem::take(&mut data)),
-                AesFilter {
-                    met: ggcomp.met,
-                    pbox: false,
-                },
+                AesFilter {},
             ));
         if ggcomp.hover {
             ent_commands.insert(geom::PopUp {});

--- a/src/funcplot.rs
+++ b/src/funcplot.rs
@@ -163,20 +163,22 @@ fn plot_spike(
 }
 
 /// Plot a box where the color is the mean of the samples.
-pub fn plot_box_point(n_cond: usize, cond_index: usize) -> Shape {
-    let box_size = 40.;
+pub fn plot_box_point(n_cond: usize, cond_index: f32, cat_index: f32) -> Shape {
+    const BOX_SIZE: f32 = 40.;
     let box_center = if n_cond == 0 {
         0.
     } else {
-        let center = cond_index as f32 * box_size * 1.2;
-        center - n_cond as f32 * box_size * 1.2 / 2.
+        let center = cond_index * BOX_SIZE * 1.2;
+        center - n_cond as f32 * BOX_SIZE * 1.2 / 2.
     };
+    let h_pad = BOX_SIZE * 0.2 * (cat_index != 0.) as usize as f32;
+    let y = BOX_SIZE * cat_index + h_pad;
     let mut path_builder = PathBuilder::new();
-    path_builder.move_to(Vec2::new(box_center - box_size / 2., 0.));
-    path_builder.line_to(Vec2::new(box_center + box_size / 2., 0.));
-    path_builder.line_to(Vec2::new(box_center + box_size / 2., box_size));
-    path_builder.line_to(Vec2::new(box_center - box_size / 2., box_size));
-    path_builder.line_to(Vec2::new(box_center - box_size / 2., 0.));
+    path_builder.move_to(Vec2::new(box_center - BOX_SIZE / 2., y));
+    path_builder.line_to(Vec2::new(box_center + BOX_SIZE / 2., y));
+    path_builder.line_to(Vec2::new(box_center + BOX_SIZE / 2., y + BOX_SIZE));
+    path_builder.line_to(Vec2::new(box_center - BOX_SIZE / 2., y + BOX_SIZE));
+    path_builder.line_to(Vec2::new(box_center - BOX_SIZE / 2., y));
     path_builder.build()
 }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -4,9 +4,7 @@ use serde::{Deserialize, Serialize};
 /// When in a Entity with `Aesthetics`, it will plot whatever aes to
 /// the arrows in the map.
 #[derive(Component)]
-pub struct GeomArrow {
-    pub plotted: bool,
-}
+pub struct GeomArrow {}
 
 /// Side of the arrow a plot (box point, histogram or legend) is referring to.
 #[derive(Hash, PartialEq, Eq, Debug, Clone, Deserialize, Serialize, Default, Component)]
@@ -71,9 +69,7 @@ impl GeomHist {
 /// When in a Entity with `Aesthetics`, it will plot whatever aes to
 /// the circles in the map.
 #[derive(Component)]
-pub struct GeomMetabolite {
-    pub plotted: bool,
-}
+pub struct GeomMetabolite;
 
 /// Component applied to all Hist-like entities (spawned by a GeomKde, GeomHist, etc. aesthetic)
 /// This allow us to query for systems like normalize or drag.
@@ -96,7 +92,6 @@ pub struct Xaxis {
     pub arrow_size: f32,
     pub xlimits: (f32, f32),
     pub side: Side,
-    pub plot: HistPlot,
     pub node_id: u64,
     pub conditions: Vec<String>,
 }
@@ -105,7 +100,10 @@ pub struct Xaxis {
 /// Used to plot boxpoints next to each other, indicating
 /// isozymes for instance (x-axis is conditions).
 #[derive(Component)]
-pub struct YCategory(pub Vec<usize>);
+pub struct YCategory {
+    pub idx: Vec<usize>,
+    pub tags: Vec<Option<String>>,
+}
 
 /// Component that marks something susceptible of being dragged/rotated.
 #[derive(Debug, Component, Default)]
@@ -148,7 +146,4 @@ pub struct AnyTag {
 /// Mark aesthetics as pertaining to mets.
 /// Used to filter removal queries.
 #[derive(Component, Clone)]
-pub struct AesFilter {
-    pub met: bool,
-    pub pbox: bool,
-}
+pub struct AesFilter {}

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -101,6 +101,12 @@ pub struct Xaxis {
     pub conditions: Vec<String>,
 }
 
+/// Component that indicates a Y-categorical axis.
+/// Used to plot boxpoints next to each other, indicating
+/// isozymes for instance (x-axis is conditions).
+#[derive(Component)]
+pub struct YCategory(pub Vec<usize>);
+
 /// Component that marks something susceptible of being dragged/rotated.
 #[derive(Debug, Component, Default)]
 pub struct Drag {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 //! Unit testing on app-updates.
 use crate::aesthetics::{AesPlugin, Aesthetics, Distribution, Gy, Point, RestoreEvent, Unscale};
-use crate::geom::{AesFilter, GeomHist, HistTag, Xaxis};
+use crate::geom::{AesFilter, GeomHist, HistTag, Xaxis, YCategory};
 use crate::gui::{file_drop, ActiveData, UiState};
 use crate::{data, escher, geom, info};
 use bevy::prelude::*;
@@ -11,10 +11,12 @@ use bevy::tasks::IoTaskPool;
 
 /// Setup to test systems that require [`AsserServer`] as an argument.
 /// Adapted form bevy source code.
-fn setup<'appl>(app: &'appl mut App, asset_path: &str) {
+fn setup(app: &mut App, asset_path: &str) {
     IoTaskPool::get_or_init(Default::default);
-    let mut asset_plug = AssetPlugin::default();
-    asset_plug.file_path = asset_path.to_string();
+    let asset_plug = AssetPlugin {
+        file_path: asset_path.to_string(),
+        ..Default::default()
+    };
     app.add_plugins(asset_plug);
 }
 
@@ -68,7 +70,7 @@ fn gy_dist_aes_spaws_xaxis_spawns_hist() {
     assert!(app
         .world_mut()
         .query::<&Xaxis>()
-        .iter(&app.world())
+        .iter(app.world())
         .next()
         .is_some());
 
@@ -77,7 +79,7 @@ fn gy_dist_aes_spaws_xaxis_spawns_hist() {
     assert!(app
         .world_mut()
         .query::<(&HistTag, &Shape)>()
-        .iter(&app.world())
+        .iter(app.world())
         .next()
         .is_some());
 }
@@ -98,6 +100,7 @@ fn point_dist_aes_spaws_box_axis_spawns_box() {
             met: false,
             pbox: true,
         })
+        .insert(YCategory(vec![0, 1, 2]))
         .insert(GeomHist::right(geom::HistPlot::Kde));
     // and for Paths with ArrowTag
     let path_builder = PathBuilder::new();
@@ -127,7 +130,7 @@ fn point_dist_aes_spaws_box_axis_spawns_box() {
     assert!(app
         .world_mut()
         .query::<(&Xaxis, &Unscale)>()
-        .iter(&app.world())
+        .iter(app.world())
         .next()
         .is_some());
 
@@ -137,7 +140,7 @@ fn point_dist_aes_spaws_box_axis_spawns_box() {
     assert!(app
         .world_mut()
         .query::<(&HistTag, &Unscale, &Shape)>()
-        .iter(&app.world())
+        .iter(app.world())
         .next()
         .is_some());
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,6 +24,9 @@ fn setup(app: &mut App, asset_path: &str) {
 fn gy_dist_aes_spaws_xaxis_spawns_hist() {
     // Setup app
     let mut app = App::new();
+    setup(&mut app, "assets");
+    app.world().get_resource::<AssetServer>().unwrap();
+    app.init_asset::<Font>();
     // build_axes queries for aesthetics
     app.world_mut()
         .spawn(Aesthetics {
@@ -36,10 +39,7 @@ fn gy_dist_aes_spaws_xaxis_spawns_hist() {
             vec![1f32, 2., 1.],
             vec![6f32, 2., 6.],
         ]))
-        .insert(AesFilter {
-            met: false,
-            pbox: false,
-        })
+        .insert(AesFilter {})
         .insert(GeomHist::right(geom::HistPlot::Kde));
     // and for Paths with ArrowTag
     let path_builder = PathBuilder::new();
@@ -54,13 +54,9 @@ fn gy_dist_aes_spaws_xaxis_spawns_hist() {
             node_id: 9,
             direction: Vec2::new(0., 1.),
         },
-        AesFilter {
-            met: false,
-            pbox: false,
-        },
+        AesFilter {},
     ));
 
-    setup(&mut app, "assets");
     app.insert_resource(ActiveData::default());
     app.insert_resource(UiState::default());
     app.add_plugins(AesPlugin);
@@ -88,6 +84,9 @@ fn gy_dist_aes_spaws_xaxis_spawns_hist() {
 fn point_dist_aes_spaws_box_axis_spawns_box() {
     // Setup app
     let mut app = App::new();
+    setup(&mut app, "assets");
+    app.world().get_resource::<AssetServer>().unwrap();
+    app.init_asset::<Font>();
     // build_axes queries for aesthetics
     app.world_mut()
         .spawn(Aesthetics {
@@ -96,11 +95,15 @@ fn point_dist_aes_spaws_box_axis_spawns_box() {
         })
         .insert(Gy {})
         .insert(Point(vec![1f32, 2., 2.]))
-        .insert(AesFilter {
-            met: false,
-            pbox: true,
+        .insert(AesFilter {})
+        .insert(YCategory {
+            idx: vec![0, 1, 2],
+            tags: vec![
+                Some(String::from("a")),
+                Some(String::from("b")),
+                Some(String::from("c")),
+            ],
         })
-        .insert(YCategory(vec![0, 1, 2]))
         .insert(GeomHist::right(geom::HistPlot::Kde));
     // and for Paths with ArrowTag
     let path_builder = PathBuilder::new();
@@ -115,13 +118,9 @@ fn point_dist_aes_spaws_box_axis_spawns_box() {
             node_id: 9,
             direction: Vec2::new(0., 1.),
         },
-        AesFilter {
-            met: false,
-            pbox: true,
-        },
+        AesFilter {},
     ));
 
-    setup(&mut app, "asset1");
     app.insert_resource(UiState::default());
     app.insert_resource(ActiveData::default());
     app.add_plugins(AesPlugin);


### PR DESCRIPTION
Closes #47.

### Description

Add the ability to have more than one boxpoint per arrow and condition, stacking them horizontally. This allows the representation of isozymes.

![image](https://github.com/user-attachments/assets/494e5333-5cfa-4426-8644-4352a5baaab4)

Text tags are added as appear in the data to indicate the particular variant and the horizontal alignment is shared across conditions.

### Grammar of graphics

A new aesthetic was introduced to indicate the variable that controls horizontal stacking: `stack`. `y` would have been also a good choice but, since it will always clash with the hist/kde `y` (since they require different types), it was avoided.

```python
ggshu(df, aes=aes(stack="isozyme", color="enz_concentration")) + geom_boxpoint()
```

### Implementation

* `src/data.rs`: A new optional `Data` input field is accepted for metabolism input. This triggers the generation of boxpoint `Aesthetic` entities with a new component that indicates the horizontal index and the name (sharing order with the reaction identifiers).
* `src/aes.rs` and `src/funcplot.rs`: boxpoints can add different boxes per arrow in the x-axis (condition-wise as before) and now also in the y-axis (box_variant-wise).
* `src/aes.rs`: `Text2d` tags are spawned together with each box per condition and variant.
* `ggshu`: the new aes was added to `geom_boxpoint`, with its corresponding data handling.