### PR TITLE
[FEAT] CLI to load map and data paths

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,11 +2,21 @@
 use bevy::prelude::{App, Entity, FileDragAndDrop};
 use bevy::window::PrimaryWindow;
 use std::env;
+use std::io;
 use std::path::PathBuf;
+use thiserror::Error;
 
 pub struct CliArgs {
     pub map_path: Option<PathBuf>,
     pub data_path: Option<PathBuf>,
+}
+
+#[derive(Error, Debug)]
+pub enum InitCliError {
+    #[error("supplied path is invalid.")]
+    InvalidPathError(#[from] io::Error),
+    #[error("window not initialized.")]
+    UninitWindow,
 }
 
 pub fn parse_args() -> CliArgs {
@@ -29,28 +39,27 @@ pub fn parse_args() -> CliArgs {
 
 /// Generate `FileDragAndDrop` such that the map and/or data
 /// if supplied as CLI args are later loaded.
-pub fn handle_cli_args(app: &mut App, cli_args: CliArgs) {
-    let Some((win, _)) = app
+pub fn handle_cli_args(app: &mut App, cli_args: CliArgs) -> Result<(), InitCliError> {
+    let (win, _) = app
         .world_mut()
         .query::<(Entity, &PrimaryWindow)>()
         .iter(app.world())
         .next()
-    else {
-        return;
-    };
+        .ok_or(InitCliError::UninitWindow)?;
     // paths are canonicalized so that they are not interpreted
     // to be in the assets directory by bevy's `AssetLoader`.
     if let Some(map_path) = cli_args.map_path {
         app.world_mut().send_event(FileDragAndDrop::DroppedFile {
             window: win,
-            path_buf: map_path.canonicalize().unwrap(),
+            path_buf: map_path.canonicalize()?,
         });
     }
 
     if let Some(data_path) = cli_args.data_path {
         app.world_mut().send_event(FileDragAndDrop::DroppedFile {
             window: win,
-            path_buf: data_path.canonicalize().unwrap(),
+            path_buf: data_path.canonicalize()?,
         });
     }
+    Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,8 +15,8 @@ pub fn parse_args() -> CliArgs {
     let (map_path, data_path) = args.iter().skip(1).zip(args.iter().skip(2)).fold(
         (None, None),
         |(map, data), (arg, next)| match arg.as_str() {
-            "--map" => (Some(PathBuf::from(next)), data),
-            "--data" => (map, Some(PathBuf::from(next))),
+            "--map" | "-m" => (Some(PathBuf::from(next)), data),
+            "--data" | "-d" => (map, Some(PathBuf::from(next))),
             _ => (map, data),
         },
     );

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,56 @@
+//! Module that handles CLI to supply input files as arguments to the executable.
+use bevy::prelude::{App, Entity, FileDragAndDrop};
+use bevy::window::PrimaryWindow;
+use std::env;
+use std::path::PathBuf;
+
+pub struct CliArgs {
+    pub map_path: Option<PathBuf>,
+    pub data_path: Option<PathBuf>,
+}
+
+pub fn parse_args() -> CliArgs {
+    let args: Vec<String> = env::args().collect();
+    // the last args take priority
+    let (map_path, data_path) = args.iter().skip(1).zip(args.iter().skip(2)).fold(
+        (None, None),
+        |(map, data), (arg, next)| match arg.as_str() {
+            "--map" => (Some(PathBuf::from(next)), data),
+            "--data" => (map, Some(PathBuf::from(next))),
+            _ => (map, data),
+        },
+    );
+
+    CliArgs {
+        map_path,
+        data_path,
+    }
+}
+
+/// Generate `FileDragAndDrop` such that the map and/or data
+/// if supplied as CLI args are later loaded.
+pub fn handle_cli_args(app: &mut App, cli_args: CliArgs) {
+    let Some((win, _)) = app
+        .world_mut()
+        .query::<(Entity, &PrimaryWindow)>()
+        .iter(app.world())
+        .next()
+    else {
+        return;
+    };
+    // paths are canonicalized so that they are not interpreted
+    // to be in the assets directory by bevy's `AssetLoader`.
+    if let Some(map_path) = cli_args.map_path {
+        app.world_mut().send_event(FileDragAndDrop::DroppedFile {
+            window: win,
+            path_buf: map_path.canonicalize().unwrap(),
+        });
+    }
+
+    if let Some(data_path) = cli_args.data_path {
+        app.world_mut().send_event(FileDragAndDrop::DroppedFile {
+            window: win,
+            path_buf: data_path.canonicalize().unwrap(),
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ use bevy_pancam::{PanCam, PanCamPlugin};
 use bevy_prototype_lyon::prelude::*;
 
 mod aesthetics;
+#[cfg(not(target_arch = "wasm32"))]
+mod cli;
 mod data;
 mod escher;
 mod funcplot;
@@ -23,7 +25,8 @@ use screenshot::{RawAsset, RawFontStorage};
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    App::new()
+    let mut app = App::new();
+    let app = app
         .insert_resource(WinitSettings::desktop_app())
         .add_plugins(
             DefaultPlugins
@@ -47,8 +50,12 @@ fn main() {
         .add_plugins(data::DataPlugin)
         .add_systems(Startup, setup_system)
         .add_plugins(aesthetics::AesPlugin)
-        .add_plugins(legend::LegendPlugin)
-        .run();
+        .add_plugins(legend::LegendPlugin);
+
+    let cli_args = cli::parse_args();
+    cli::handle_cli_args(app, cli_args);
+
+    app.run();
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,13 @@ fn main() {
         .add_plugins(legend::LegendPlugin);
 
     let cli_args = cli::parse_args();
-    cli::handle_cli_args(app, cli_args);
+    if let Err(e) = cli::handle_cli_args(app, cli_args) {
+        use cli::InitCliError::*;
+        match e {
+            InvalidPathError(error) => error!("Supplied path as arg is invalid: {error}"),
+            UninitWindow => error!("Window was not initialized!"),
+        }
+    }
 
     app.run();
 }


### PR DESCRIPTION
Related to #44 

### Description

The user can provide CLI arguments to the map and data to be used by shu, without interacting with the GUI.

### Implementation

Before running the app, `FileDragAndDrop` events are emitted if arguments are supplied, triggering map/data loading by the common `src/gui.rs` functionality.

For #44, we are still missing programmatic screenshots and theming.