### PR TITLE
Fix SVG output of map text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ mod screenshot;
 mod tests;
 
 use escher::{EscherMap, EscherPlugin, MapState};
-use screenshot::{RawAsset, RawFontStorage};
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
@@ -219,9 +218,6 @@ fn setup_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         reaction_data: None,
         loaded: false,
     });
-    let fira: Handle<RawAsset> = asset_server.load("fonts/FiraSans-Bold.tttx");
-    let assis: Handle<RawAsset> = asset_server.load("fonts/Assistant-Regular.tttx");
-    commands.insert_resource(RawFontStorage { fira, assis });
 
     commands
         .spawn((

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -103,7 +103,7 @@ fn save_svg_file(
         &Visibility,
     )>,
     text_query: Query<
-        (&Text, &TextFont, &TextColor, &Transform, &Visibility),
+        (&Text2d, &TextFont, &TextColor, &Transform, &Visibility),
         (Without<Xmin>, Without<Xmax>, Without<IgnoreSave>),
     >,
     // legend part


### PR DESCRIPTION
After updating to bevy 0.15, there was a lingering regression that required updating the text query in the svg screenshot system. Additionally, some code could be removed since the atlas font data can now be directly accessed.