### PR TITLE
[FEAT] geom_col

### DIFF
--- a/ggshu/ggshu/__init__.py
+++ b/ggshu/ggshu/__init__.py
@@ -4,6 +4,7 @@ from .geoms import GeomHist as geom_hist
 from .geoms import GeomKde as geom_kde
 from .geoms import GeomMetabolite as geom_metabolite
 from .geoms import GeomBoxPoint as geom_boxpoint
+from .geoms import GeomColumn as geom_column
 from .ggdata import PlotData as ggmap
 from .jupyter import Shu
 

--- a/ggshu/ggshu/aes.py
+++ b/ggshu/ggshu/aes.py
@@ -13,6 +13,8 @@ def aes(
     color: Optional[str] = None,
     size: Optional[str] = None,
     stack: Optional[str] = None,
+    ymin: Optional[str] = None,
+    ymax: Optional[str] = None,
 ) -> Aesthetics:
     """Map from dataframe variables to grammar graphics variables."""
     # instead of using **kwargs, we specify the exact accepted aes
@@ -23,6 +25,8 @@ def aes(
         "metabolite": metabolite,
         "condition": condition,
         "y": y,
+        "ymin": ymin,
+        "ymax": ymax,
         "color": color,
         "size": size,
         "stack": stack,

--- a/ggshu/ggshu/geoms.py
+++ b/ggshu/ggshu/geoms.py
@@ -180,6 +180,30 @@ class GeomMetabolite(GeomArrow):
         self.post_init()
 
 
+class GeomColumn(GeomArrow):
+    """Geometric mapping from aesthetics to column plots at both sides of the arrows(reactions) in the metabolic map.
+
+    Parameters
+    ----------
+    aes: Optional[Aesthetics]
+        with accepted aesthetics being `{"reaction", "y", "ymin", "ymax"}`.
+        "y" is required but "ymin" and/or "ymax" are optional and may not be
+        provided for all cases where "y" is present.
+    """
+
+    def __init__(
+        self,
+        *,
+        df: Optional[pd.DataFrame] = None,
+        aes: Optional[Aesthetics] = None,
+        side: str = "right",
+    ):
+        super().__init__(df=df, aes=aes)
+        prefix = "left_" if side == "left" else ""
+        self.mapping = {key: f"{prefix}column_{key}" for key in ["y", "ymin", "ymax"]}
+        self.post_init()
+
+
 class GeomBoxPoint(Geom):
     """Geometric mapping from aesthetics to the coloured boxes in the metabolic map.
 

--- a/src/aesthetics.rs
+++ b/src/aesthetics.rs
@@ -73,7 +73,7 @@ pub struct SummaryDist<T>(pub Vec<(T, Option<T>, Option<T>)>);
 struct PointAxis {}
 /// Marker trait for Xaxis for column plots.
 #[derive(Component)]
-struct ColumnAxis {}
+pub struct ColumnAxis {}
 
 /// For a geom plotted in an axis, get the lower and upper bounds of the data
 /// and define a marker trait.
@@ -745,6 +745,12 @@ fn plot_side_column(
                     0.0,
                     COLUMN_PLOT_HEIGHT,
                 );
+                let min_height = heights.0[index]
+                    .1
+                    .map(|x| lerp(x, min_val, max_val, 0.0, COLUMN_PLOT_HEIGHT));
+                let max_height = heights.0[index]
+                    .2
+                    .map(|x| lerp(x, min_val, max_val, 0.0, COLUMN_PLOT_HEIGHT));
 
                 trans.translation.z += 10.;
                 let color_hex = match geom.side {
@@ -758,7 +764,13 @@ fn plot_side_column(
                         .iter()
                         .position(|x| x == aes.condition.as_ref().unwrap_or(&String::from("")))
                         .unwrap_or(0) as f32;
-                    let column = plot_column(height, axis.conditions.len(), cond_idx);
+                    let column = plot_column(
+                        height,
+                        min_height,
+                        max_height,
+                        axis.conditions.len(),
+                        cond_idx,
+                    );
                     (
                         GeometryBuilder::build_as(&column),
                         trans.with_scale(Vec3::new(1., 1., 1.)),

--- a/src/funcplot.rs
+++ b/src/funcplot.rs
@@ -183,7 +183,13 @@ pub fn plot_box_point(n_cond: usize, cond_index: f32, cat_index: f32) -> Shape {
 }
 
 /// Plot a column bar.
-pub fn plot_column(height: f32, n_cond: usize, cond_index: f32) -> Shape {
+pub fn plot_column(
+    height: f32,
+    ymin: Option<f32>,
+    ymax: Option<f32>,
+    n_cond: usize,
+    cond_index: f32,
+) -> Shape {
     const COL_WIDTH: f32 = 40.;
     let column_center = if n_cond == 0 {
         0.
@@ -197,6 +203,17 @@ pub fn plot_column(height: f32, n_cond: usize, cond_index: f32) -> Shape {
     path_builder.line_to(Vec2::new(column_center + COL_WIDTH / 2., height));
     path_builder.line_to(Vec2::new(column_center + COL_WIDTH / 2., 0.0));
     path_builder.line_to(Vec2::new(column_center - COL_WIDTH / 2., 0.0));
+    // path_builder.close();
+    if let Some(min_height) = ymin {
+        path_builder.move_to(Vec2::new(column_center, min_height));
+        path_builder.line_to(Vec2::new(column_center, height));
+        // path_builder.close();
+    }
+    if let Some(max_height) = ymax {
+        path_builder.move_to(Vec2::new(column_center, height));
+        path_builder.line_to(Vec2::new(column_center, max_height));
+        // path_builder.close();
+    }
     path_builder.build()
 }
 

--- a/src/funcplot.rs
+++ b/src/funcplot.rs
@@ -182,6 +182,24 @@ pub fn plot_box_point(n_cond: usize, cond_index: f32, cat_index: f32) -> Shape {
     path_builder.build()
 }
 
+/// Plot a column bar.
+pub fn plot_column(height: f32, n_cond: usize, cond_index: f32) -> Shape {
+    const COL_WIDTH: f32 = 40.;
+    let column_center = if n_cond == 0 {
+        0.
+    } else {
+        let center = cond_index * COL_WIDTH * 1.2;
+        center - n_cond as f32 * COL_WIDTH * 1.2 / 2.
+    };
+    let mut path_builder = PathBuilder::new();
+    path_builder.move_to(Vec2::new(column_center - COL_WIDTH / 2., 0.0));
+    path_builder.line_to(Vec2::new(column_center - COL_WIDTH / 2., height));
+    path_builder.line_to(Vec2::new(column_center + COL_WIDTH / 2., height));
+    path_builder.line_to(Vec2::new(column_center + COL_WIDTH / 2., 0.0));
+    path_builder.line_to(Vec2::new(column_center - COL_WIDTH / 2., 0.0));
+    path_builder.build()
+}
+
 type TextBundle<T> = (T, TextFont, TextColor, Transform);
 
 /// Three text tags to be used as Components to build a an axis scale.

--- a/src/legend/mod.rs
+++ b/src/legend/mod.rs
@@ -4,7 +4,7 @@ use bevy::color::Srgba;
 use bevy::prelude::*;
 
 use crate::{
-    aesthetics::{Aesthetics, Distribution, Gcolor, Gy, Point, Unscale},
+    aesthetics::{Aesthetics, ColumnAxis, Distribution, Gcolor, Gy, Point, SummaryDist, Unscale},
     funcplot::{linspace, max_f32, min_f32},
     geom::{GeomArrow, GeomHist, GeomMetabolite, PopUp, Side, Xaxis},
     gui::{or_color, UiState},
@@ -182,7 +182,7 @@ fn color_legend_histograms(
     mut writer: TextUiWriter,
     mut legend_query: Query<(Entity, &mut Node, &Side, &Children), With<LegendHist>>,
     // Unscale means would mean that is not a histogram
-    axis_query: Query<&Xaxis, Without<Unscale>>,
+    axis_query: Query<&Xaxis, Or<(Without<Unscale>, With<ColumnAxis>)>>,
     // only queries for collapsing the legend if no hist data is displayed anymore
     hist_query: Query<
         &GeomHist,
@@ -190,7 +190,7 @@ fn color_legend_histograms(
             With<Gy>,
             Without<PopUp>,
             With<Aesthetics>,
-            With<Distribution<f32>>,
+            Or<(With<Distribution<f32>>, With<SummaryDist<f32>>)>,
         ),
     >,
     mut img_query: Query<&mut ImageNode>,


### PR DESCRIPTION
### Description

Implement `geom_col` for column plots. This is a middle ground between a distribution and a boxpoint, since it is able to plot the value (like the boxpoint) and error bars (both confidence/credibility intervals, quantiles, etc.).

![image](https://github.com/user-attachments/assets/379cd4c8-ab19-40ac-abbc-ef2598fbc311)


### Implementation

* [x] New input data fields. It is allowed to have column data with/without ymin and with/without ymax; plotting the errorbars is optional.
* [x] Box point axes generation is now generic so that specific `Xaxis` are built for columns.
* [x] The histogram legend a color change is reused for columns if present.
* [x] `geom_column` was added to the python API.